### PR TITLE
Add --discard-untrimmed to extract_sites

### DIFF
--- a/modules/extract_sites/main.nf
+++ b/modules/extract_sites/main.nf
@@ -18,6 +18,7 @@ process extract_sites {
         --revcomp \
         -e $params.error_rate \
         -O $params.min_overlap \
+        --discard-untrimmed \
         -o sites_cutadapt.fasta \
         -j $task.cpus \
         $reads

--- a/modules/map_inserts/main.nf
+++ b/modules/map_inserts/main.nf
@@ -12,7 +12,7 @@ process map_inserts {
 
     script:
     """
-    minimap2 -ax $params.tech -t $task.cpus $fna $ins_seqs | samtools view -@ $task.cpus -b - | samtools sort - -@ $task.cpus -o mapped_inserts.bam
+    minimap2 -ax $params.tech -t $task.cpus --secondary=no $fna $ins_seqs | samtools view -@ $task.cpus -b - | samtools sort - -@ $task.cpus -o mapped_inserts.bam
     samtools index -@ $task.cpus mapped_inserts.bam
     samtools flagstats -@ $task.cpus -O tsv mapped_inserts.bam > mapped_insert_stats.tsv
     """


### PR DESCRIPTION
Cutadapt was passing untrimmed reads through to sites.fasta. Adding --discard-untrimmed ensures only reads where the site adapter was found are kept.